### PR TITLE
Independence from the dateconv.Epoch type (#10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,15 @@ $ nepcal -d
 ```
 
 ## Installation
-Pre-built binaries are available in the [Releases](https://github.com/nepcal/nepcal/releases) page.
+Pre-built binaries are available in the [Releases](https://github.com/srishanbhattarai/nepcal/releases) page.
 
 You can also install `nepcal` manually if you have Go installed
 ```
-go get -v github.com/nepcal/nepcal
+go get -v github.com/srishanbhattarai/nepcal
 ```
 
 ## Contributing
-Please file an issue if you have any problems with `nepcal` or, have a look at the issues page for contributing on existing issues. Also, read the [code of conduct](https://github.com/nepcal/nepcal/blob/master/CODE_OF_CONDUCT.md).
+Please file an issue if you have any problems with `nepcal` or, have a look at the issues page for contributing on existing issues. Also, read the [code of conduct](https://github.com/srishanbhattarai/nepcal/blob/master/CODE_OF_CONDUCT.md).
 
 ## License
 MIT

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-clone_folder: c:\gopath\src\github.com\nepcal\nepcal
+clone_folder: c:\gopath\src\github.com\srishanbhattarai\nepcal
 
 environment:
   GOPATH: c:\gopath

--- a/calendar.go
+++ b/calendar.go
@@ -23,7 +23,7 @@ func newCalendar() *calendar {
 // Render prints the BS calendar for the given time.Time.
 // For printing formatted/aligned output, we use a tabwriter from the
 // standard library. It doesn't support ANSI escapes so we cant have
-// color/other enhancements to the output.(https://github.com/nepcal/nepcal/issues/4)
+// color/other enhancements to the output.(https://github.com/srishanbhattarai/nepcal/issues/4)
 func (c *calendar) Render(parentWriter io.Writer, ad time.Time) {
 	w := tabwriter.NewWriter(parentWriter, 0, 0, 1, ' ', 0)
 	bs := dateconv.ToBS(ad)

--- a/calendar.go
+++ b/calendar.go
@@ -24,9 +24,8 @@ func newCalendar() *calendar {
 // For printing formatted/aligned output, we use a tabwriter from the
 // standard library. It doesn't support ANSI escapes so we cant have
 // color/other enhancements to the output.(https://github.com/nepcal/nepcal/issues/4)
-func (c *calendar) Render(parentWriter io.Writer, t time.Time) {
+func (c *calendar) Render(parentWriter io.Writer, ad time.Time) {
 	w := tabwriter.NewWriter(parentWriter, 0, 0, 1, ' ', 0)
-	ad := toEpoch(t)
 	bs := dateconv.ToBS(ad)
 
 	c.renderBSDateHeader(w, bs)
@@ -41,7 +40,7 @@ func (c *calendar) Render(parentWriter io.Writer, t time.Time) {
 // to be handled separately is because there is a skew in each month which
 // determines which day the month starts from - we need to tab space the 'skew' number
 // of days, then start printing from the day after the skew.
-func (c *calendar) renderFirstRow(w io.Writer, ad, bs dateconv.Epoch) {
+func (c *calendar) renderFirstRow(w io.Writer, ad, bs time.Time) {
 	offset := c.calculateSkew(ad, bs)
 	for i := 0; i < offset; i++ {
 		fmt.Fprintf(w, "\t")
@@ -58,8 +57,9 @@ func (c *calendar) renderFirstRow(w io.Writer, ad, bs dateconv.Epoch) {
 // renderCalWithoutFirstRow renders the rest of the calendar without the first row.
 // renderFirstRow will handle that due to special circumstances. We basically loop over
 // each row and print 7 numbers until we are at the end of the month.
-func (c *calendar) renderCalWithoutFirstRow(w io.Writer, ad, bs dateconv.Epoch) {
-	daysInMonth := dateconv.BsDaysInMonthsByYear[bs.Year][bs.Month-1]
+func (c *calendar) renderCalWithoutFirstRow(w io.Writer, ad, bs time.Time) {
+	bsyy, bsmm, _ := bs.Date()
+	daysInMonth := dateconv.BsDaysInMonthsByYear[bsyy][int(bsmm-1)]
 
 	for c.val < daysInMonth {
 		start := daysInMonth - c.val
@@ -88,37 +88,24 @@ func (c *calendar) renderStaticDaysHeader(w io.Writer) {
 }
 
 // renderBSDateHeader prints the date corresponding to the epoch.
-func (c *calendar) renderBSDateHeader(w io.Writer, e dateconv.Epoch) {
-	fmt.Fprintf(w, "\t\t%s %d, %d\n\t", dateconv.BSMonths[e.Month], e.Day, e.Year)
+func (c *calendar) renderBSDateHeader(w io.Writer, e time.Time) {
+	yy, mm, dd := e.Date()
+
+	fmt.Fprintf(w, "\t\t%s %d, %d\n\t", dateconv.BSMonths[int(mm)], dd, yy)
 }
 
 // calculateSkew calculates the offset at the beginning of the month. Given an AD and
 // BS date, we calculate the diff in days from the BS date to the start of the month in BS.
 // We subtract that from the AD date, and get the weekday.
 // For example, a skew of 2 means the month starts from Tuesday.
-func (c *calendar) calculateSkew(ad, bs dateconv.Epoch) int {
-	adDate := fromEpoch(ad)
-	dayDiff := (bs.Day % 7) - 1
-	adWithoutbsDiffDays := adDate.AddDate(0, 0, -dayDiff)
+func (c *calendar) calculateSkew(ad, bs time.Time) int {
+	_, _, bsdd := bs.Date()
+
+	dayDiff := (bsdd % 7) - 1
+	adWithoutbsDiffDays := ad.AddDate(0, 0, -dayDiff)
 	d := adWithoutbsDiffDays.Weekday()
 
 	// Since time.Weekday is an iota and not an iota + 1 we can avoid
 	// subtracting 1 from the return value.
 	return int(d)
-}
-
-// fromEpoch creates a time.Time type from an Epoch
-func fromEpoch(e dateconv.Epoch) time.Time {
-	return time.Date(e.Year, time.Month(e.Month), e.Day, 0, 0, 0, 0, time.UTC)
-}
-
-// toEpoch creates a dateconv.Epoch from a time.Time
-func toEpoch(t time.Time) dateconv.Epoch {
-	yy, mm, dd := t.Date()
-
-	return dateconv.Epoch{
-		Year:  yy,
-		Month: int(mm),
-		Day:   dd,
-	}
 }

--- a/calendar_test.go
+++ b/calendar_test.go
@@ -21,32 +21,32 @@ var fixtures = map[string]time.Time{
 func TestCalculateSkew(t *testing.T) {
 	tests := []struct {
 		name     string
-		adDate   dateconv.Epoch
-		bsDate   dateconv.Epoch
+		adDate   time.Time
+		bsDate   time.Time
 		expected int
 	}{
 		{
 			"less than 7",
-			toEpoch(fixtures["May17"]),
-			dateconv.ToBS(toEpoch(fixtures["May17"])),
+			fixtures["May17"],
+			dateconv.ToBS(fixtures["May17"]),
 			2,
 		},
 		{
 			"less than 7",
-			toEpoch(fixtures["May19"]),
-			dateconv.ToBS(toEpoch(fixtures["May19"])),
+			fixtures["May19"],
+			dateconv.ToBS(fixtures["May19"]),
 			2,
 		},
 		{
 			"less than 7",
-			toEpoch(fixtures["June15"]),
-			dateconv.ToBS(toEpoch(fixtures["June15"])),
+			fixtures["June15"],
+			dateconv.ToBS(fixtures["June15"]),
 			5,
 		},
 		{
 			"more than 7",
-			toEpoch(fixtures["May26"]),
-			dateconv.ToBS(toEpoch(fixtures["May26"])),
+			fixtures["May26"],
+			dateconv.ToBS(fixtures["May26"]),
 			2,
 		},
 	}

--- a/dateconv/dateconv.go
+++ b/dateconv/dateconv.go
@@ -1,17 +1,9 @@
 // Package dateconv deals with conversion of A.D. dates to B.S dates
-// In either format, the date is represented by an Epoch struct.
 package dateconv
 
 import (
 	"time"
 )
-
-// Epoch represents a single date irrespective of AD or BS.
-type Epoch struct {
-	Year  int
-	Month int
-	Day   int
-}
 
 // The list of months in the B.S. system.
 const (
@@ -169,9 +161,8 @@ func adDaysInMonths(isLeapYear bool) []int {
 // ToBS handles conversion of an Anno Domini (A.D) date into the Nepali
 // date format - Bikram Samwad (B.S).The approximate difference is
 // 56 years, 8 months.
-func ToBS(AD Epoch) Epoch {
-	adLBound := dateFromEpoch(Epoch{ADLBoundY, ADLBoundM, ADLBoundD})
-	adDate := dateFromEpoch(AD)
+func ToBS(adDate time.Time) time.Time {
+	adLBound := toTime(ADLBoundY, ADLBoundM, ADLBoundD)
 	if !adDate.After(adLBound) {
 		panic("Can only work with dates after 1943 April 14.")
 	}
@@ -194,12 +185,12 @@ func ToBS(AD Epoch) Epoch {
 		return -1, -1, -1
 	}()
 
-	return Epoch{year, month, days}
+	return toTime(year, month, days)
 }
 
-// dateFromEpoch creates a time.Time type from an Epoch
-func dateFromEpoch(e Epoch) time.Time {
-	return time.Date(e.Year, time.Month(e.Month), e.Day, 0, 0, 0, 0, time.UTC)
+// toTime creates a new time.Time with the basic yy/mm/dd parameters.
+func toTime(yy, mm, dd int) time.Time {
+	return time.Date(yy, time.Month(mm), dd, 0, 0, 0, 0, time.UTC)
 }
 
 // isLeapYear returns if the passed in year is a leap year.

--- a/dateconv/dateconv_test.go
+++ b/dateconv/dateconv_test.go
@@ -2,6 +2,7 @@ package dateconv
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -9,38 +10,38 @@ import (
 func TestToBS(t *testing.T) {
 	tests := []struct {
 		name   string
-		input  Epoch
-		output Epoch
+		input  time.Time
+		output time.Time
 	}{
 		{
 			"case1",
-			Epoch{2018, 04, 01},
-			Epoch{2074, 12, 18},
+			toTime(2018, 04, 01),
+			toTime(2074, 12, 18),
 		},
 		{
 			"case2",
-			Epoch{1943, 04, 15},
-			Epoch{2000, 01, 02},
+			toTime(1943, 04, 15),
+			toTime(2000, 01, 02),
 		},
 		{
 			"case3",
-			Epoch{2018, 04, 17},
-			Epoch{2075, 01, 04},
+			toTime(2018, 04, 17),
+			toTime(2075, 01, 04),
 		},
 		{
 			"case4",
-			Epoch{2018, 05, 01},
-			Epoch{2075, 01, 18},
+			toTime(2018, 05, 01),
+			toTime(2075, 01, 18),
 		},
 		{
 			"case5",
-			Epoch{1960, 9, 16},
-			Epoch{2017, 06, 1},
+			toTime(1960, 9, 16),
+			toTime(2017, 06, 1),
 		},
 		{
 			"case6",
-			Epoch{2037, 9, 16},
-			Epoch{-1, -1, -1},
+			toTime(2037, 9, 16),
+			toTime(-1, -1, -1),
 		},
 	}
 
@@ -52,7 +53,7 @@ func TestToBS(t *testing.T) {
 
 	t.Run("panics if date is before 1943 April 14", func(t *testing.T) {
 		assert.Panics(t, func() {
-			ToBS(Epoch{1943, 04, 01}) // april 1
+			ToBS(toTime(1943, 04, 01)) // april 1
 		}, "Can only work with dates after 1943 April 14")
 	})
 }

--- a/main.go
+++ b/main.go
@@ -40,13 +40,12 @@ func render(dateFlag bool) {
 func showDate(w io.Writer, t time.Time) {
 	yy, mm, dd := t.Date()
 
-	bs := dateconv.ToBS(
-		dateconv.Epoch{
-			Year:  yy,
-			Month: int(mm),
-			Day:   dd,
-		},
-	)
+	bsyy, bsmm, bsdd := dateconv.ToBS(toTime(yy, mm, dd)).Date()
 
-	fmt.Fprintf(w, "%s %d, %d\n", dateconv.BSMonths[bs.Month], bs.Day, bs.Year)
+	fmt.Fprintf(w, "%s %d, %d\n", dateconv.BSMonths[int(bsmm)], bsdd, bsyy)
+}
+
+// toTime creates a new time.Time with the basic yy/mm/dd parameters.
+func toTime(yy int, mm time.Month, dd int) time.Time {
+	return time.Date(yy, mm, dd, 0, 0, 0, 0, time.UTC)
 }


### PR DESCRIPTION
Closes #10 
This was basically a proxy to `time.Time` which made it easy to interoperate. With a helper like `toTime()` this becomes totally unnecessary. There's one less exported type from `dateconv` and everything is within the realm of the standard lib.