### PR TITLE
(refactor) Make the tabwriter be part of the calendar state

### DIFF
--- a/calendar_test.go
+++ b/calendar_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -53,7 +54,7 @@ func TestCalculateSkew(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			c := newCalendar()
+			c := newCalendar(os.Stdout)
 			assert.Equal(t, test.expected, c.calculateSkew(test.adDate, test.bsDate))
 		})
 	}
@@ -93,8 +94,8 @@ func TestRenderCalendar(t *testing.T) {
 
 		t.Run(test.name, func(t *testing.T) {
 			b.Reset()
-			c := newCalendar()
-			c.Render(b, test.t)
+			c := newCalendar(b)
+			c.Render(test.t)
 			assert.Equal(t, clean(test.expected), clean(b.String()))
 		})
 	}

--- a/cli.go
+++ b/cli.go
@@ -14,8 +14,8 @@ type nepcalCli struct{}
 
 // Shows the calendar for the current day.
 func (nepcalCli) showCalendar(c *cli.Context) {
-	cal := newCalendar()
-	cal.Render(writer, time.Now())
+	cal := newCalendar(writer)
+	cal.Render(time.Now())
 }
 
 // Shows the date for the provided time. Returns a cli 'action'.


### PR DESCRIPTION
* This cleans things up so that each render function doesn't need an
io.Writer passed to it.