### PR TITLE
Get total number of days in a BS year

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 Inspired from the Linux command line tool `cal`, `nepcal` adds a few nifty features especially for Nepali ([B.S](https://en.wikipedia.org/wiki/Vikram_Samvat)) dates.
 
 ## Feature Rundown
+
 Complete instructions on how to use each of these features are mentioned below.
 
 * [x] Show the current Nepali month's calendar
@@ -13,26 +14,33 @@ Complete instructions on how to use each of these features are mentioned below.
 * [ ] Convert an B.S. date into A.D.
 
 ## Installation
-Pre-built tarball binaries are available in the [Releases](https://github.com/srishanbhattarai/nepcal/releases) page. 
-Download and untar the binary for your platform, then move it into your `$PATH` e.g. `/usr/local/bin`.
+
+Pre-built tarball binaries are available in the [Releases](https://github.com/srishanbhattarai/nepcal/releases) page. Download and untar the binary for your platform, then move it into your `$PATH` e.g. `/usr/local/bin`.
 
 You might need to give the script execution permissions. On Linux and MacOS this would mean using `chmod` as follows:
+
 ```
 $ chmod +x /usr/local/bin/nepcal
 ```
 
 ### MacOS via Homebrew
+
 Tap the repository first.
+
 ```
 $ brew tap srishanbhattarai/nepcal https://github.com/srishanbhattarai/nepcal
 ```
+
 Then, run:
+
 ```
 $ brew install nepcal
 ```
 
 ### Manual Installation
+
 You can also install `nepcal` manually if you have Go installed
+
 ```
 $ go get -v github.com/srishanbhattarai/nepcal
 ```
@@ -40,9 +48,11 @@ $ go get -v github.com/srishanbhattarai/nepcal
 Run `nepcal` on your terminal - if you see some formatted output, you are good to go!
 
 ## Usage
+
 Complete details can be found by running `nepcal` without any arguments.
 
-### Monthly calendar
+### Monthly Calendar
+
 ```
 $ nepcal cal # or nepcal c
 
@@ -56,6 +66,7 @@ $ nepcal cal # or nepcal c
 ```
 
 ### Today's date and day
+
 ```
 $ nepcal date # or nepcal d
 
@@ -63,7 +74,9 @@ $ nepcal date # or nepcal d
 ```
 
 ### Convert A.D. date to B.S.
+
 Use the `mm-dd-yyyy` format when converting A.D. to B.S.
+
 ```
 $ nepcal conv adtobs 08-21-1994
 
@@ -71,7 +84,9 @@ $ nepcal conv adtobs 08-21-1994
 ```
 
 ## Contributing
+
 Please file an issue if you have any problems with `nepcal` or, have a look at the issues page for contributing on existing issues. Also, read the [code of conduct](https://github.com/srishanbhattarai/nepcal/blob/master/CODE_OF_CONDUCT.md).
 
 ## License
+
 [MIT](LICENSE)

--- a/dateconv/dateconv.go
+++ b/dateconv/dateconv.go
@@ -83,7 +83,7 @@ func TotalDaysInBSYear(bsYear int) (int, error) {
 
 	sum := 0
 	for _, value := range days {
-		sum = sum + value
+		sum += value
 	}
 
 	return sum, nil

--- a/dateconv/dateconv.go
+++ b/dateconv/dateconv.go
@@ -75,13 +75,13 @@ func BsDaysInMonthsByYear(yy int, mm time.Month) (int, bool) {
 
 // TotalDaysInBSYear returns total number of days in a particular BS year.
 func TotalDaysInBSYear(bsYear int) (int, error) {
-	sum := 0
 	days, ok := bsDaysInMonthsByYear[bsYear]
 
-	if ok == false {
+	if !ok {
 		return -1, fmt.Errorf("Year should be in between %d and %d", bsLBound, bsUBound)
 	}
 
+	sum := 0
 	for _, value := range days {
 		sum = sum + value
 	}

--- a/dateconv/dateconv.go
+++ b/dateconv/dateconv.go
@@ -3,6 +3,7 @@
 package dateconv
 
 import (
+	"fmt"
 	"time"
 )
 
@@ -70,6 +71,22 @@ func BsDaysInMonthsByYear(yy int, mm time.Month) (int, bool) {
 	}
 
 	return months[query], true
+}
+
+// TotalDaysInBSYear returns total number of days in a particular BS year.
+func TotalDaysInBSYear(bsYear int) (int, error) {
+	sum := 0
+	days, ok := bsDaysInMonthsByYear[bsYear]
+
+	if ok == false {
+		return -1, fmt.Errorf("Year should be in between %d and %d", bsLBound, bsUBound)
+	}
+
+	for _, value := range days {
+		sum = sum + value
+	}
+
+	return sum, nil
 }
 
 // toTime creates a new time.Time with the basic yy/mm/dd parameters.

--- a/dateconv/dateconv_test.go
+++ b/dateconv/dateconv_test.go
@@ -1,6 +1,7 @@
 package dateconv
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -174,4 +175,31 @@ func TestBsDaysInMonthsByYear(t *testing.T) {
 			assert.Equal(t, test.expectedBool, ok)
 		})
 	}
+}
+
+func TestTotalDaysInBSYear(t *testing.T) {
+	tests := []struct {
+		name     string
+		year     int
+		expected int
+	}{
+		{"returns total number of days in 2001 BS", 2001, 365},
+		{"returns total number of days in 2077 BS", 2077, 366},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			total, err := TotalDaysInBSYear(test.year)
+
+			assert.Equal(t, test.expected, total, err)
+		})
+	}
+
+	t.Run("errors if BS year is out of range", func(t *testing.T) {
+		_, err := TotalDaysInBSYear(3050)
+
+		if assert.Error(t, err) {
+			assert.Equal(t, fmt.Errorf("Year should be in between %d and %d", bsLBound, bsUBound), err)
+		}
+	})
 }


### PR DESCRIPTION
* Added a function to retrieve total number of days in a particular BS year
* Added tests for the new function

This is a nice addition to the `dateconv` package even though it isn't really needed for AD to BS conversion.

Another motive for this PR is that I need this in something that I'm working on. 😆 