### PR TITLE
Use nepali spelling for shrawan

### DIFF
--- a/dateconv/constants.go
+++ b/dateconv/constants.go
@@ -34,7 +34,7 @@ var bsMonths = map[int]string{
 	baisakh:  "बैशाख",
 	jestha:   "जेठ",
 	ashar:    "असार",
-	shrawan:  "सावन",
+	shrawan:  "साउन",
 	bhadra:   "भदौ",
 	ashoj:    "असोज",
 	kartik:   "कार्तिक",

--- a/dateconv/dateconv.go
+++ b/dateconv/dateconv.go
@@ -25,7 +25,7 @@ func NewBSDate(yy, mm, dd int) BSDate {
 }
 
 // ToBS handles conversion of an Anno Domini (A.D) date into the Nepali
-// date format - Bikram Sambad (B.S).The approximate difference is
+// date format - Bikram Sambat (B.S).The approximate difference is
 // 56 years, 8 months.
 func ToBS(adDate time.Time) BSDate {
 	adLBound := toTime(adLBoundY, adLBoundM, adLBoundD)


### PR DESCRIPTION
सावन  is considered as Hindi.

```diff
- सावन
+ साउन
```

Reference: https://en.wikipedia.org/wiki/Vikram_Samvat#Lunar_metrics