### PR TITLE
refactor: Move calculateSkew logic to be part of the dateconv package

### DIFF
--- a/calendar_test.go
+++ b/calendar_test.go
@@ -2,12 +2,10 @@ package main
 
 import (
 	"bytes"
-	"os"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/srishanbhattarai/nepcal/dateconv"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,48 +14,6 @@ var fixtures = map[string]time.Time{
 	"May19":  time.Date(2018, time.May, 19, 0, 0, 0, 0, time.UTC),
 	"May26":  time.Date(2018, time.May, 26, 0, 0, 0, 0, time.UTC),
 	"June15": time.Date(2018, time.June, 15, 0, 0, 0, 0, time.UTC),
-}
-
-// Test the 'calculateSkew' function.
-func TestCalculateSkew(t *testing.T) {
-	tests := []struct {
-		name     string
-		adDate   time.Time
-		bsDate   dateconv.BSDate
-		expected int
-	}{
-		{
-			"less than 7",
-			fixtures["May17"],
-			dateconv.ToBS(fixtures["May17"]),
-			2,
-		},
-		{
-			"less than 7",
-			fixtures["May19"],
-			dateconv.ToBS(fixtures["May19"]),
-			2,
-		},
-		{
-			"less than 7",
-			fixtures["June15"],
-			dateconv.ToBS(fixtures["June15"]),
-			5,
-		},
-		{
-			"more than 7",
-			fixtures["May26"],
-			dateconv.ToBS(fixtures["May26"]),
-			2,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			c := newCalendar(os.Stdout)
-			assert.Equal(t, test.expected, c.calculateSkew(test.adDate, test.bsDate))
-		})
-	}
 }
 
 // Test the 'renderCalendar' function

--- a/dateconv/dateconv.go
+++ b/dateconv/dateconv.go
@@ -19,8 +19,28 @@ func (b BSDate) Date() (int, int, int) {
 	return b.year, b.month, b.days
 }
 
-// NewBSDate is a constructor for a new Bikram Sambat date.
-func NewBSDate(yy, mm, dd int) BSDate {
+// DaysInMonth returns the total number of days in the month for this date.
+// The invariant here is that 'b.month' is always a valid month.
+func (b BSDate) DaysInMonth() (int, bool) {
+	return BsDaysInMonthsByYear(b.year, time.Month(b.month))
+}
+
+// MonthStartsAtDay calculates the offset at the beginning of the month. Given an AD date
+// we calculate the diff in days from the BS date to the start of the month in BS.
+// We subtract that from the AD date, and get the weekday.
+// For example, a value of 2 means the month starts from Tuesday.
+func (b BSDate) MonthStartsAtDay(ad time.Time) int {
+	dayDiff := (b.days % 7) - 1
+	adWithoutbsDiffDays := ad.AddDate(0, 0, -dayDiff)
+	d := adWithoutbsDiffDays.Weekday()
+
+	// Since time.Weekday is an iota and not an iota + 1 we can avoid
+	// subtracting 1 from the return value.
+	return int(d)
+}
+
+// newBSDate is a constructor for a new Bikram Sambat date.
+func newBSDate(yy, mm, dd int) BSDate {
 	return BSDate{yy, mm, dd}
 }
 
@@ -51,7 +71,7 @@ func ToBS(adDate time.Time) BSDate {
 		return -1, -1, -1
 	}()
 
-	return NewBSDate(year, month, days)
+	return newBSDate(year, month, days)
 }
 
 // GetBSMonthName returns the B.S. month name from the time.Month type.

--- a/dateconv/dateconv_test.go
+++ b/dateconv/dateconv_test.go
@@ -17,42 +17,42 @@ func TestToBS(t *testing.T) {
 		{
 			"case1",
 			toTime(2018, 04, 01),
-			NewBSDate(2074, 12, 18),
+			newBSDate(2074, 12, 18),
 		},
 		{
 			"case2",
 			toTime(1943, 04, 15),
-			NewBSDate(2000, 01, 02),
+			newBSDate(2000, 01, 02),
 		},
 		{
 			"case3",
 			toTime(2018, 04, 17),
-			NewBSDate(2075, 01, 04),
+			newBSDate(2075, 01, 04),
 		},
 		{
 			"case4",
 			toTime(2018, 05, 01),
-			NewBSDate(2075, 01, 18),
+			newBSDate(2075, 01, 18),
 		},
 		{
 			"case5",
 			toTime(1960, 9, 16),
-			NewBSDate(2017, 06, 1),
+			newBSDate(2017, 06, 1),
 		},
 		{
 			"case6",
 			toTime(2037, 9, 16),
-			NewBSDate(-1, -1, -1),
+			newBSDate(-1, -1, -1),
 		},
 		{
 			"case7",
 			toTime(2019, 06, 15),
-			NewBSDate(2076, 02, 32),
+			newBSDate(2076, 02, 32),
 		},
 		{
 			"case8",
 			toTime(2019, 06, 13),
-			NewBSDate(2076, 02, 30),
+			newBSDate(2076, 02, 30),
 		},
 	}
 
@@ -212,4 +212,52 @@ func TestTotalDaysInBSYear(t *testing.T) {
 			assert.Equal(t, fmt.Errorf("Year should be in between %d and %d", bsLBound, bsUBound), err)
 		}
 	})
+}
+
+// Test the 'MonthStartsAtDay' function.
+func TestMonthStartsAtDay(t *testing.T) {
+	var fixtures = map[string]time.Time{
+		"May17":  time.Date(2018, time.May, 17, 0, 0, 0, 0, time.UTC),
+		"May19":  time.Date(2018, time.May, 19, 0, 0, 0, 0, time.UTC),
+		"May26":  time.Date(2018, time.May, 26, 0, 0, 0, 0, time.UTC),
+		"June15": time.Date(2018, time.June, 15, 0, 0, 0, 0, time.UTC),
+	}
+
+	tests := []struct {
+		name     string
+		adDate   time.Time
+		bsDate   BSDate
+		expected int
+	}{
+		{
+			"less than 7",
+			fixtures["May17"],
+			ToBS(fixtures["May17"]),
+			2,
+		},
+		{
+			"less than 7",
+			fixtures["May19"],
+			ToBS(fixtures["May19"]),
+			2,
+		},
+		{
+			"less than 7",
+			fixtures["June15"],
+			ToBS(fixtures["June15"]),
+			5,
+		},
+		{
+			"more than 7",
+			fixtures["May26"],
+			ToBS(fixtures["May26"]),
+			2,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, test.bsDate.MonthStartsAtDay(test.adDate))
+		})
+	}
 }


### PR DESCRIPTION
This should have been part of the package long ago. The main package
currently relied on a lot of logic to compute which exact day the month
started on so that the first date on the calendar could be offset-ed by
the exact day.