### PR TITLE
Convert incoming dates to UTC regardless of time/timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Calendar and conversion utilities for Nepali dates
 
-Inspired from the Linux command line tool `cal`, `nepcal` adds a few nifty features especially for Nepali ([B.S](https://en.wikipedia.org/wiki/Vikram_Samvat)) dates.
+Inspired from the Linux command line tool `cal`, `nepcal` adds a few nifty features especially for Nepali ([B.S.](https://en.wikipedia.org/wiki/Vikram_Samvat)) dates.
 
 ## Feature Rundown
 
@@ -70,7 +70,7 @@ $ nepcal cal # or nepcal c
 ```
 $ nepcal date # or nepcal d
 
-सावन 29, 2075 मंगलबार
+साउन 29, 2075 मंगलबार
 ```
 
 ### Convert A.D. date to B.S.

--- a/dateconv/dateconv.go
+++ b/dateconv/dateconv.go
@@ -49,16 +49,23 @@ func newBSDate(yy, mm, dd int) BSDate {
 // 56 years, 8 months.
 func ToBS(adDate time.Time) BSDate {
 	adLBound := toTime(adLBoundY, adLBoundM, adLBoundD)
+
+	// Convert incoming date to UTC
+	adYear, adMonth, adDay := adDate.Date()
+	adDateUTC := toTime(adYear, int(adMonth), adDay)
+
 	if !adDate.After(adLBound) {
 		panic("Can only work with dates after 1943 April 14.")
 	}
-	totalDiff := int(adDate.Sub(adLBound).Hours() / 24)
+
+	totalDiff := int(adDateUTC.Sub(adLBound).Hours() / 24)
 
 	// Redistribute the diff along the BS data grid
 	year, month, days := func() (int, int, int) {
 		for i := bsLBound; i < bsUBound; i++ {
 			for j := 0; j < 12; j++ {
 				days := bsDaysInMonthsByYear[i][j]
+
 				if days <= totalDiff {
 					totalDiff = totalDiff - days
 					continue
@@ -111,14 +118,15 @@ func BsDaysInMonthsByYear(yy int, mm time.Month) (int, bool) {
 }
 
 // TotalDaysInBSYear returns total number of days in a particular BS year.
-func TotalDaysInBSYear(bsYear int) (int, error) {
-	days, ok := bsDaysInMonthsByYear[bsYear]
+func TotalDaysInBSYear(year int) (int, error) {
+	days, ok := bsDaysInMonthsByYear[year]
 
 	if !ok {
 		return -1, fmt.Errorf("Year should be in between %d and %d", bsLBound, bsUBound)
 	}
 
 	sum := 0
+
 	for _, value := range days {
 		sum += value
 	}

--- a/dateconv/dateconv_test.go
+++ b/dateconv/dateconv_test.go
@@ -2,11 +2,23 @@ package dateconv
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 )
+
+// dummyNepaliTime returns a time between 00:00 to 05:45
+// which when converted to UTC is the previous day
+func dummyNepaliTime(yy int, mm int, dd int) time.Time {
+	loc, _ := time.LoadLocation("Asia/Kathmandu")
+
+	hour := rand.Intn(5)
+	minute := rand.Intn(45)
+
+	return time.Date(yy, time.Month(mm), dd, hour, minute, 0, 0, loc)
+}
 
 func TestToBS(t *testing.T) {
 	tests := []struct {
@@ -53,6 +65,11 @@ func TestToBS(t *testing.T) {
 			"case8",
 			toTime(2019, 06, 13),
 			newBSDate(2076, 02, 30),
+		},
+		{
+			"case9",
+			dummyNepaliTime(2019, 05, 05),
+			newBSDate(2076, 01, 22),
 		},
 	}
 


### PR DESCRIPTION
This is something that I found a while back, decided to send in a PR after 3 months or so. 😆 

https://github.com/srishanbhattarai/nepcal/blob/master/dateconv/dateconv.go#L55

When you send in a datetime in a different timezone this line here will try to convert the date to UTC. The `totalDiff` in that case is different than what the user expects and thus the conversion is inaccurate. 

I figured this out unintentionally when passing `adDate` as `time.Now()` during 1:00 am NPT. I then tried to use the binary which passed in `time.Now()` to figure out the current Nepali date.

https://github.com/srishanbhattarai/nepcal/blob/master/cli.go#L15-L19

It had the same problem and was showing the previous Nepali date as the output. The result was skewed by `+5:45` meaning that `nepcal` command would only be accurate after 5:45 am NPT for the current time.

**Solution:**

Convert any incoming date to UTC format regardless of the time and the time zone.
