### PR TITLE
Add function to calculate total number of days spanned in current year

### DIFF
--- a/dateconv/dateconv.go
+++ b/dateconv/dateconv.go
@@ -132,15 +132,11 @@ func TotalDaysInBSYear(year int) (int, error) {
 	return sum, nil
 }
 
-// now returns the current time
-var now = func() time.Time {
-	return time.Now()
-}
-
-// TotalDaysSpanned returns the total number of days spanned in the
-// current year inclusive of the current day.
-func TotalDaysSpanned() (int, error) {
-	bsDate := ToBS(now())
+// totalDaysSpannedUntilDate is an abstraction for TotalDaysSpanned to have control
+// control over time struct. This allows tests to pass in any time value for easier
+// testing.
+func totalDaysSpannedUntilDate(now time.Time) (int, error) {
+	bsDate := ToBS(now)
 
 	days, ok := bsDaysInMonthsByYear[bsDate.year]
 	if !ok {
@@ -153,6 +149,12 @@ func TotalDaysSpanned() (int, error) {
 	}
 
 	return sum, nil
+}
+
+// TotalDaysSpanned returns the total number of days spanned in the
+// current year inclusive of the current day.
+func TotalDaysSpanned() (int, error) {
+	return totalDaysSpannedUntilDate(time.Now())
 }
 
 // toTime creates a new time.Time with the basic yy/mm/dd parameters.

--- a/dateconv/dateconv.go
+++ b/dateconv/dateconv.go
@@ -151,7 +151,7 @@ func TotalDaysSpanned() (int, error) {
 
 	sum := 0
 
-	for i := 0; i < bsDate.month; i++ {
+	for i := 0; i < bsDate.month-1; i++ {
 		sum += days[i]
 	}
 

--- a/dateconv/dateconv.go
+++ b/dateconv/dateconv.go
@@ -120,13 +120,11 @@ func BsDaysInMonthsByYear(yy int, mm time.Month) (int, bool) {
 // TotalDaysInBSYear returns total number of days in a particular BS year.
 func TotalDaysInBSYear(year int) (int, error) {
 	days, ok := bsDaysInMonthsByYear[year]
-
 	if !ok {
 		return -1, fmt.Errorf("Year should be in between %d and %d", bsLBound, bsUBound)
 	}
 
 	sum := 0
-
 	for _, value := range days {
 		sum += value
 	}
@@ -143,19 +141,16 @@ var now = func() time.Time {
 // current year inclusive of the current day.
 func TotalDaysSpanned() (int, error) {
 	bsDate := ToBS(now())
-	days, ok := bsDaysInMonthsByYear[bsDate.year]
 
+	days, ok := bsDaysInMonthsByYear[bsDate.year]
 	if !ok {
 		return -1, fmt.Errorf("Year should be in between %d and %d", bsLBound, bsUBound)
 	}
 
-	sum := 0
-
+	sum := bsDate.days
 	for i := 0; i < bsDate.month-1; i++ {
 		sum += days[i]
 	}
-
-	sum += bsDate.days
 
 	return sum, nil
 }

--- a/dateconv/dateconv.go
+++ b/dateconv/dateconv.go
@@ -134,9 +134,15 @@ func TotalDaysInBSYear(year int) (int, error) {
 	return sum, nil
 }
 
-// TotalDaysSpanned returns the total number of days spanned in the current year.
+// now returns the current time
+var now = func() time.Time {
+	return time.Now()
+}
+
+// TotalDaysSpanned returns the total number of days spanned in the
+// current year inclusive of the current day.
 func TotalDaysSpanned() (int, error) {
-	bsDate := ToBS(time.Now())
+	bsDate := ToBS(now())
 	days, ok := bsDaysInMonthsByYear[bsDate.year]
 
 	if !ok {

--- a/dateconv/dateconv.go
+++ b/dateconv/dateconv.go
@@ -134,6 +134,26 @@ func TotalDaysInBSYear(year int) (int, error) {
 	return sum, nil
 }
 
+// TotalDaysSpanned returns the total number of days spanned in the current year.
+func TotalDaysSpanned() (int, error) {
+	bsDate := ToBS(time.Now())
+	days, ok := bsDaysInMonthsByYear[bsDate.year]
+
+	if !ok {
+		return -1, fmt.Errorf("Year should be in between %d and %d", bsLBound, bsUBound)
+	}
+
+	sum := 0
+
+	for i := 0; i < bsDate.month; i++ {
+		sum += days[i]
+	}
+
+	sum += bsDate.days
+
+	return sum, nil
+}
+
 // toTime creates a new time.Time with the basic yy/mm/dd parameters.
 func toTime(yy, mm, dd int) time.Time {
 	return time.Date(yy, time.Month(mm), dd, 0, 0, 0, 0, time.UTC)

--- a/dateconv/dateconv_test.go
+++ b/dateconv/dateconv_test.go
@@ -233,10 +233,10 @@ func TestTotalDaysInBSYear(t *testing.T) {
 
 func TestMonthStartsAtDay(t *testing.T) {
 	var fixtures = map[string]time.Time{
-		"May 17, 2018":  time.Date(2018, time.May, 17, 0, 0, 0, 0, time.UTC),
-		"May 19, 2018":  time.Date(2018, time.May, 19, 0, 0, 0, 0, time.UTC),
-		"May 26, 2018":  time.Date(2018, time.May, 26, 0, 0, 0, 0, time.UTC),
-		"June 15, 2018": time.Date(2018, time.June, 15, 0, 0, 0, 0, time.UTC),
+		"May 17 2018":  time.Date(2018, time.May, 17, 0, 0, 0, 0, time.UTC),
+		"May 19 2018":  time.Date(2018, time.May, 19, 0, 0, 0, 0, time.UTC),
+		"May 26 2018":  time.Date(2018, time.May, 26, 0, 0, 0, 0, time.UTC),
+		"June 15 2018": time.Date(2018, time.June, 15, 0, 0, 0, 0, time.UTC),
 	}
 
 	tests := []struct {

--- a/dateconv/dateconv_test.go
+++ b/dateconv/dateconv_test.go
@@ -231,13 +231,12 @@ func TestTotalDaysInBSYear(t *testing.T) {
 	})
 }
 
-// Test the 'MonthStartsAtDay' function.
 func TestMonthStartsAtDay(t *testing.T) {
 	var fixtures = map[string]time.Time{
-		"May17":  time.Date(2018, time.May, 17, 0, 0, 0, 0, time.UTC),
-		"May19":  time.Date(2018, time.May, 19, 0, 0, 0, 0, time.UTC),
-		"May26":  time.Date(2018, time.May, 26, 0, 0, 0, 0, time.UTC),
-		"June15": time.Date(2018, time.June, 15, 0, 0, 0, 0, time.UTC),
+		"May 17, 2018":  time.Date(2018, time.May, 17, 0, 0, 0, 0, time.UTC),
+		"May 19, 2018":  time.Date(2018, time.May, 19, 0, 0, 0, 0, time.UTC),
+		"May 26, 2018":  time.Date(2018, time.May, 26, 0, 0, 0, 0, time.UTC),
+		"June 15, 2018": time.Date(2018, time.June, 15, 0, 0, 0, 0, time.UTC),
 	}
 
 	tests := []struct {
@@ -277,4 +276,39 @@ func TestMonthStartsAtDay(t *testing.T) {
 			assert.Equal(t, test.expected, test.bsDate.MonthStartsAtDay(test.adDate))
 		})
 	}
+}
+
+func TestTotalDaysSpanned(t *testing.T) {
+	tests := []struct {
+		name     string
+		date     time.Time
+		expected int
+	}{
+		{"June 13 2018", toTime(2018, 8, 03), 112},
+		{"June 13 2019", toTime(2019, 8, 03), 112},
+		{"April 12 2020", toTime(2020, 04, 12), 365},
+		{"April 13 2020", toTime(2020, 04, 13), 1},
+		{"April 14 2020", toTime(2020, 04, 14), 2},
+		{"April 13 2021", toTime(2021, 04, 13), 366},
+		{"April 14 2021", toTime(2021, 04, 14), 1},
+		{"April 15 2021", toTime(2021, 04, 15), 2},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			now = func() time.Time { return test.date }
+			total, err := TotalDaysSpanned()
+
+			assert.Equal(t, test.expected, total, err)
+		})
+	}
+
+	t.Run("errors if BS year is out of range", func(t *testing.T) {
+		now = func() time.Time { return toTime(3050, 06, 15) }
+		_, err := TotalDaysSpanned()
+
+		if assert.Error(t, err) {
+			assert.Equal(t, fmt.Errorf("Year should be in between %d and %d", bsLBound, bsUBound), err)
+		}
+	})
 }

--- a/dateconv/dateconv_test.go
+++ b/dateconv/dateconv_test.go
@@ -278,7 +278,7 @@ func TestMonthStartsAtDay(t *testing.T) {
 	}
 }
 
-func TestTotalDaysSpanned(t *testing.T) {
+func TestTotalDaysSpannedUntilDate(t *testing.T) {
 	tests := []struct {
 		name     string
 		date     time.Time
@@ -296,16 +296,15 @@ func TestTotalDaysSpanned(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			now = func() time.Time { return test.date }
-			total, err := TotalDaysSpanned()
+			total, err := totalDaysSpannedUntilDate(test.date)
 
 			assert.Equal(t, test.expected, total, err)
 		})
 	}
 
 	t.Run("errors if BS year is out of range", func(t *testing.T) {
-		now = func() time.Time { return toTime(3050, 06, 15) }
-		_, err := TotalDaysSpanned()
+		date := toTime(3050, 06, 15)
+		_, err := totalDaysSpannedUntilDate(date)
 
 		if assert.Error(t, err) {
 			assert.Equal(t, fmt.Errorf("Year should be in between %d and %d", bsLBound, bsUBound), err)

--- a/dateconv/dateconv_test.go
+++ b/dateconv/dateconv_test.go
@@ -233,10 +233,10 @@ func TestTotalDaysInBSYear(t *testing.T) {
 
 func TestMonthStartsAtDay(t *testing.T) {
 	var fixtures = map[string]time.Time{
-		"May 17 2018":  time.Date(2018, time.May, 17, 0, 0, 0, 0, time.UTC),
-		"May 19 2018":  time.Date(2018, time.May, 19, 0, 0, 0, 0, time.UTC),
-		"May 26 2018":  time.Date(2018, time.May, 26, 0, 0, 0, 0, time.UTC),
-		"June 15 2018": time.Date(2018, time.June, 15, 0, 0, 0, 0, time.UTC),
+		"May_17_2018":  time.Date(2018, time.May, 17, 0, 0, 0, 0, time.UTC),
+		"May_19_2018":  time.Date(2018, time.May, 19, 0, 0, 0, 0, time.UTC),
+		"May_26_2018":  time.Date(2018, time.May, 26, 0, 0, 0, 0, time.UTC),
+		"June_15_2018": time.Date(2018, time.June, 15, 0, 0, 0, 0, time.UTC),
 	}
 
 	tests := []struct {
@@ -247,26 +247,26 @@ func TestMonthStartsAtDay(t *testing.T) {
 	}{
 		{
 			"less than 7",
-			fixtures["May17"],
-			ToBS(fixtures["May17"]),
+			fixtures["May_17_2018"],
+			ToBS(fixtures["May_17_2018"]),
 			2,
 		},
 		{
 			"less than 7",
-			fixtures["May19"],
-			ToBS(fixtures["May19"]),
+			fixtures["May_19_2018"],
+			ToBS(fixtures["May_19_2018"]),
 			2,
 		},
 		{
 			"less than 7",
-			fixtures["June15"],
-			ToBS(fixtures["June15"]),
+			fixtures["June_15_2018"],
+			ToBS(fixtures["June_15_2018"]),
 			5,
 		},
 		{
 			"more than 7",
-			fixtures["May26"],
-			ToBS(fixtures["May26"]),
+			fixtures["May_26_2018"],
+			ToBS(fixtures["May_26_2018"]),
 			2,
 		},
 	}
@@ -284,14 +284,14 @@ func TestTotalDaysSpanned(t *testing.T) {
 		date     time.Time
 		expected int
 	}{
-		{"June 13 2018", toTime(2018, 8, 03), 112},
-		{"June 13 2019", toTime(2019, 8, 03), 112},
-		{"April 12 2020", toTime(2020, 04, 12), 365},
-		{"April 13 2020", toTime(2020, 04, 13), 1},
-		{"April 14 2020", toTime(2020, 04, 14), 2},
-		{"April 13 2021", toTime(2021, 04, 13), 366},
-		{"April 14 2021", toTime(2021, 04, 14), 1},
-		{"April 15 2021", toTime(2021, 04, 15), 2},
+		{"June_13_2018", toTime(2018, 8, 03), 112},
+		{"June_13_2019", toTime(2019, 8, 03), 112},
+		{"April_12_2020", toTime(2020, 04, 12), 365},
+		{"April_13_2020", toTime(2020, 04, 13), 1},
+		{"April_14_2020", toTime(2020, 04, 14), 2},
+		{"April_13_2021", toTime(2021, 04, 13), 366},
+		{"April_14_2021", toTime(2021, 04, 14), 1},
+		{"April_15_2021", toTime(2021, 04, 15), 2},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
* Added a new function `TotalDaysSpanned` to dateconv util
* Added tests

**Note:** A private function `totalDaysSpannedUntilDate` has been created so that we can easily pass any `time.Time` value from the test file.