### PR TITLE
bug: Fix tests failing on Go 1.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,5 @@ require (
 	github.com/stretchr/testify v1.3.0
 	github.com/urfave/cli v1.21.0
 )
+
+go 1.13

--- a/main.go
+++ b/main.go
@@ -18,10 +18,6 @@ const versionNumber = "0.4.0"
 // Cheap testing.
 var writer io.Writer = os.Stdout
 
-func init() {
-	flag.Parse()
-}
-
 func main() {
 	runCli()
 }
@@ -33,6 +29,7 @@ func runCli() {
 }
 
 func bootstrapCli() *cli.App {
+	flag.Parse()
 	nc := nepcalCli{}
 
 	app := cli.NewApp()


### PR DESCRIPTION
The issue is an upstream one. Refer to https://github.com/golang/go/issues/31859 for all the details.
On a surfacial level, it breaks client code that calls `flag.Parse` in `init` functions. The solution,
albeit unsatisfactory, is to move the `flag.Parse` call to a regular function instead. This pollutes
the test output slightly but CI *should* pass now.