### PR TITLE
bug: Update travis config to 1.13 Go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-go: 1.9
+go: 1.13
 before_install: go get github.com/mattn/goveralls
 install: go get -t ./...
 script:


### PR DESCRIPTION
Issue with a vendor dep not working on Go 1.9 🤷‍♂ 