### PR TITLE
Upgrade to urfave/cli v2

### DIFF
--- a/cmd/nepcal/main.go
+++ b/cmd/nepcal/main.go
@@ -35,9 +35,11 @@ func bootstrapCli() *cli.App {
 	nc := nepcalCli{}
 
 	app := &cli.App{
-		Name:    "nepcal",
-		Version: version,
-		Usage:   "Calendar and conversion utilities for Nepali dates",
+		Name:            "nepcal",
+		Version:         version,
+		Usage:           "Calendar and conversion utilities for Nepali dates",
+		HideVersion:     true,
+		HideHelpCommand: true,
 		Authors: []*cli.Author{
 			{
 				Name:  "Srishan Bhattarai",

--- a/cmd/nepcal/main.go
+++ b/cmd/nepcal/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 )
 
 const versionNumber = "v1.1.0"
@@ -32,7 +32,7 @@ func bootstrapCli() *cli.App {
 	app.Name = "nepcal"
 	app.Version = versionNumber
 	app.Usage = "Calendar and conversion utilities for Nepali dates"
-	app.Commands = []cli.Command{
+	app.Commands = []*cli.Command{
 		{
 			Name:    "cal",
 			Aliases: []string{"c"},
@@ -48,7 +48,7 @@ func bootstrapCli() *cli.App {
 		{
 			Name:  "conv",
 			Usage: "Convert AD dates to BS and vice-versa",
-			Subcommands: []cli.Command{
+			Subcommands: []*cli.Command{
 				{
 					Name:   "adtobs",
 					Usage:  "Convert AD date to BS date",

--- a/cmd/nepcal/main.go
+++ b/cmd/nepcal/main.go
@@ -2,14 +2,16 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"io"
 	"os"
+	"sort"
 	"time"
 
 	"github.com/urfave/cli/v2"
 )
 
-const versionNumber = "v1.1.0"
+const version = "v1.1.0"
 
 // Cheap testing.
 var writer io.Writer = os.Stdout
@@ -21,47 +23,61 @@ func main() {
 func runCli() {
 	cli := bootstrapCli()
 
-	cli.Run(os.Args)
+	err := cli.Run(os.Args)
+
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+	}
 }
 
 func bootstrapCli() *cli.App {
 	flag.Parse()
 	nc := nepcalCli{}
 
-	app := cli.NewApp()
-	app.Name = "nepcal"
-	app.Version = versionNumber
-	app.Usage = "Calendar and conversion utilities for Nepali dates"
-	app.Commands = []*cli.Command{
-		{
-			Name:    "cal",
-			Aliases: []string{"c"},
-			Usage:   "Show calendar for the month",
-			Action:  nc.showCalendar,
+	app := &cli.App{
+		Name:    "nepcal",
+		Version: version,
+		Usage:   "Calendar and conversion utilities for Nepali dates",
+		Authors: []*cli.Author{
+			{
+				Name:  "Srishan Bhattarai",
+				Email: "srishanbhattarai@gmail.com",
+			},
 		},
-		{
-			Name:    "date",
-			Aliases: []string{"d"},
-			Usage:   "Show today's date",
-			Action:  nc.showDate(writer, time.Now()),
-		},
-		{
-			Name:  "conv",
-			Usage: "Convert AD dates to BS and vice-versa",
-			Subcommands: []*cli.Command{
-				{
-					Name:   "adtobs",
-					Usage:  "Convert AD date to BS date",
-					Action: nc.convADToBS,
-				},
-				{
-					Name:   "bstoad",
-					Usage:  "Convert BS date to AD date",
-					Action: nc.convBSToAD,
+		Commands: []*cli.Command{
+			{
+				Name:    "cal",
+				Aliases: []string{"c"},
+				Usage:   "Show calendar for the month",
+				Action:  nc.showCalendar,
+			},
+			{
+				Name:    "date",
+				Aliases: []string{"d"},
+				Usage:   "Show today's date",
+				Action:  nc.showDate(writer, time.Now()),
+			},
+			{
+				Name:  "conv",
+				Usage: "Convert AD dates to BS and vice-versa",
+				Subcommands: []*cli.Command{
+					{
+						Name:   "tobs",
+						Usage:  "Convert AD date to BS date",
+						Action: nc.convADToBS,
+					},
+					{
+						Name:   "toad",
+						Usage:  "Convert BS date to AD date",
+						Action: nc.convBSToAD,
+					},
 				},
 			},
 		},
 	}
+
+	sort.Sort(cli.FlagsByName(app.Flags))
+	sort.Sort(cli.CommandsByName(app.Commands))
 
 	return app
 }

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.13
 
 require (
 	github.com/stretchr/testify v1.5.1
-	github.com/urfave/cli v1.22.3
+	github.com/urfave/cli/v2 v2.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/urfave/cli v1.22.3 h1:FpNT6zq26xNpHZy08emi755QwzLPs6Pukqjlc7RfOMU=
-github.com/urfave/cli v1.22.3/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/urfave/cli/v2 v2.2.0 h1:JTTnM6wKzdA0Jqodd966MVj4vWbbquZykeX1sKbe2C4=
+github.com/urfave/cli/v2 v2.2.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=


### PR DESCRIPTION
The main motive was to upgrade to the latest version of the CLI. However, I chipped in with a few minor changes that could have been a separate PR.

- Hide version global flag and help command from CLI (closes #32 as it is irrelevant and it does not need any fixing)
- Sort CLI commands by their name in help text
- Add author information in the CLI
- Set version in the CLI as it kept showing `0.4.0` even though the new version is `1.1.0`
- Renamed conversion sub-commands: `adtobs` to `tobs` and `bstoad` to `toad` (This is simple and consistent in my opinion)