### PR TITLE
Few updates to readme as per Markdown linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # nepcal &middot; [![Build Status](https://travis-ci.org/srishanbhattarai/nepcal.svg?branch=master)](https://travis-ci.org/srishanbhattarai/nepcal) [![Build status](https://ci.appveyor.com/api/projects/status/6vm0m2ph6usjvdn4/branch/master?svg=true)](https://ci.appveyor.com/project/srishanbhattarai/nepcal-j10el/branch/master) [![Coverage Status](https://coveralls.io/repos/github/srishanbhattarai/nepcal/badge.svg?branch=master&service=github)](https://coveralls.io/github/srishanbhattarai/nepcal?branch=master) [![Go Report Card](https://goreportcard.com/badge/github.com/srishanbhattarai/nepcal)](https://goreportcard.com/report/github.com/srishanbhattarai/nepcal) [![GoDoc](https://godoc.org/github.com/srishanbhattarai/nepcal?status.svg)](https://godoc.org/github.com/srishanbhattarai/nepcal)
 
-Nepcal is a command line tool and a library that provides several functionalities pertaining to [Bikram Sambat (B.S.)](https://calendars.wikia.org/wiki/Bikram_Samwat) calendars, the official calendar in Nepal. 
+Nepcal is a command line tool and a library that provides several functionalities pertaining to [Bikram Sambat (B.S.)](https://calendars.wikia.org/wiki/Bikram_Samwat) calendars, the official calendar in Nepal.
 
 ## Table of Contents
+
 * [Command Line](#command-line)
 * [Installation](#installation)
   * [Pre-built binaries](#pre-built-binaries)
@@ -17,7 +18,8 @@ Nepcal is a command line tool and a library that provides several functionalitie
 * [Library/Programmatic usage](#library)
 * [License](#license)
 
-## Command Line 
+## Command Line
+
 The `nepcal` CLI was initially inspired from the `cal` command on Linux, but expanded to have much more functionality, namely:
 
 * [x] Show the current Nepali month's calendar (Similar to `cal`)
@@ -25,35 +27,39 @@ The `nepcal` CLI was initially inspired from the `cal` command on Linux, but exp
 * [x] Convert A.D. (gregorian) dates to B.S. dates and vice-versa.
 
 ## Installation
+
 There are several ways to install the CLI. Pick the one that best suits you from the options below. In any case, run `nepcal` on your terminal; if you see some formatted output then you are good to go.
 
 ### Pre-built binaries
-Pre-built tarball executables/binaries are available in the [Releases](https://github.com/srishanbhattarai/nepcal/releases) page for MacOS, Windows, and Linux. 
+
+Pre-built tarball executables/binaries are available in the [Releases](https://github.com/srishanbhattarai/nepcal/releases) page for MacOS, Windows, and Linux.
 Download and untar the binary for your platform, then move it into your executable path. e.g. `/usr/local/bin` on Mac or Linux.
 
 You might need to give the script execution permissions. On Linux and MacOS this would mean using `chmod` as follows:
-    
-```
+
+```sh
 $ chmod +x /usr/local/bin/nepcal
 ```
 
 ### Homebrew on Mac
+
 Tap the repository first.
 
-```
+```sh
 $ brew tap srishanbhattarai/nepcal https://github.com/srishanbhattarai/nepcal
 ```
 
 Then, run:
 
-```
+```sh
 $ brew install nepcal
 ```
 
 ### Using `go get`
-You can also install `nepcal` manually if you have the Go toolchain installed
 
-```
+You can also install `nepcal` manually if you have the Go toolchain installed.
+
+```sh
 $ go get -v github.com/srishanbhattarai/nepcal/cmd/nepcal
 ```
 
@@ -63,7 +69,7 @@ Complete details can be found by running `nepcal` without any arguments.
 
 ### Monthly Calendar
 
-```
+```sh
 $ nepcal cal # or nepcal c
     चैत ११, २०७६
  Su Mo Tu We Th Fr Sa
@@ -75,35 +81,36 @@ $ nepcal cal # or nepcal c
  ३०
 ```
 
-### Today's date and day
+### Today's Date
 
-```
+```sh
 $ nepcal date # or nepcal d
 
 चैत १०, २०७६ सोमबार
 ```
 
-### Convert an A.D. date to B.S.
+### Convert A.D. to B.S.
 
 Use the `mm-dd-yyyy` format when converting A.D. to B.S.
 
-```
-$ nepcal conv adtobs 08-21-1994
+```sh
+$ nepcal conv tobs 08-21-1994
 
 भदौ ५, २०५१ आइतबार
 ```
 
-### Convert a B.S. date to A.D.
+### Convert B.S. to A.D.
 
 Use the `mm-dd-yyyy` format when converting B.S. to A.D.
 
-```
-$ nepcal conv bstoad 08-18-2053
+```sh
+$ nepcal conv toad 08-18-2053
 
 December 3, 1996 Tuesday
 ```
 
 ## Library
+
 If you would like to use `nepcal` as a Go library, the best reference is the [Godoc](https://godoc.org/github.com/srishanbhattarai/nepcal/nepcal) documentation for this package which should be fairly easy to navigate. The CLI tool is also built on this library. However, there are additional functionalities provided in the library that are not relevant in the CLI, for example the [`NumDaysSpanned()`](https://godoc.org/github.com/srishanbhattarai/nepcal/nepcal#Time.NumDaysSpanned) method.
 
 ## Contributing


### PR DESCRIPTION
- Added a new line after headings
- Added language name for code blocks
- Renamed `adtobs` to `tobs`
- Renamed `bstoad` to `toad`