### PR TITLE
Return calendar as default output of nepcal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ vendor/
 # Binaries
 bin/
 dist/
+nepcal
 
 # Project specific files
 cmd/cross/reference.json

--- a/README.md
+++ b/README.md
@@ -4,28 +4,28 @@ Nepcal is a command line tool and a library that provides several functionalitie
 
 ## Table of Contents
 
-* [Command Line](#command-line)
-* [Installation](#installation)
-  * [Pre-built binaries](#pre-built-binaries)
-  * [Homebrew on Mac](#homebrew-on-mac)
-  * [Using go get](#using-go-get)
-* [Usage](#usage)
-  * [Monthly Calendar](#monthly-calendar)
-  * [Today's date and day](#todays-date-and-day)
-  * [Convert an A.D. date to B.S.](#convert-an-ad-date-to-bs)
-  * [Convert a B.S. date to A.D.](#convert-a-bs-date-to-ad)
-* [Library/Programmatic usage](#library)
-* [Acknowledgements](#acknowledgements)
-* [Contributing](#contributing)
-* [License](#license)
+- [Command Line](#command-line)
+- [Installation](#installation)
+  - [Pre-built binaries](#pre-built-binaries)
+  - [Homebrew on Mac](#homebrew-on-mac)
+  - [Using go get](#using-go-get)
+- [Usage](#usage)
+  - [Monthly Calendar](#monthly-calendar)
+  - [Today's date and day](#todays-date-and-day)
+  - [Convert an A.D. date to B.S.](#convert-an-ad-date-to-bs)
+  - [Convert a B.S. date to A.D.](#convert-a-bs-date-to-ad)
+- [Library/Programmatic usage](#library)
+- [Acknowledgements](#acknowledgements)
+- [Contributing](#contributing)
+- [License](#license)
 
 ## Command Line
 
 The `nepcal` CLI was initially inspired from the `cal` command on Linux, but expanded to have much more functionality, namely:
 
-* Show the current Nepali month's calendar (Similar to `cal`)
-* Show today's Nepali date and day
-* Convert A.D. (gregorian) dates to B.S. dates and vice-versa.
+- Show the current Nepali month's calendar (Similar to `cal`)
+- Show today's Nepali date and day
+- Convert A.D. (gregorian) dates to B.S. dates and vice-versa.
 
 ## Installation
 
@@ -66,7 +66,7 @@ $ go get -v github.com/srishanbhattarai/nepcal/cmd/nepcal
 
 ## Usage
 
-Complete details can be found by running `nepcal help` without any arguments.
+Complete details can be found by running `nepcal help`.
 
 ### Monthly Calendar
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Nepcal is a command line tool and a library that provides several functionalitie
 
 The `nepcal` CLI was initially inspired from the `cal` command on Linux, but expanded to have much more functionality, namely:
 
-* [x] Show the current Nepali month's calendar (Similar to `cal`)
-* [x] Show today's Nepali date and day
-* [x] Convert A.D. (gregorian) dates to B.S. dates and vice-versa.
+* Show the current Nepali month's calendar (Similar to `cal`)
+* Show today's Nepali date and day
+* Convert A.D. (gregorian) dates to B.S. dates and vice-versa.
 
 ## Installation
 
@@ -66,12 +66,12 @@ $ go get -v github.com/srishanbhattarai/nepcal/cmd/nepcal
 
 ## Usage
 
-Complete details can be found by running `nepcal` without any arguments.
+Complete details can be found by running `nepcal help` without any arguments.
 
 ### Monthly Calendar
 
 ```sh
-$ nepcal cal # or nepcal c
+$ nepcal # or nepcal cal
     चैत ११, २०७६
  Su Mo Tu We Th Fr Sa
                    १

--- a/cmd/nepcal/cli.go
+++ b/cmd/nepcal/cli.go
@@ -44,7 +44,7 @@ func (nepcalCli) convADToBS(c *cli.Context) error {
 	if !validateArgs(c) {
 		fmt.Fprintln(os.Stderr, "Please supply a valid date in the format mm-dd-yyyy. Example: `nepcal conv tobs 08-21-1994`")
 
-		return cli.NewExitError("", 1)
+		return cli.Exit("", 1)
 	}
 
 	mm, dd, yy, _ := parseRawDate(c.Args().First())
@@ -54,7 +54,7 @@ func (nepcalCli) convADToBS(c *cli.Context) error {
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Please supply a date after 04/14/1943.")
 
-		return cli.NewExitError("", 1)
+		return cli.Exit("", 1)
 	}
 
 	fmt.Fprintln(globalWriter, bs.String())
@@ -67,7 +67,7 @@ func (nepcalCli) convBSToAD(c *cli.Context) error {
 	if !validateArgs(c) {
 		fmt.Fprintln(os.Stderr, "Please supply a valid date in the format mm-dd-yyyy. Example: `nepcal conv toad 08-18-2053`")
 
-		return cli.NewExitError("", 1)
+		return cli.Exit("", 1)
 	}
 
 	mm, dd, yy, _ := parseRawDate(c.Args().First())
@@ -76,7 +76,7 @@ func (nepcalCli) convBSToAD(c *cli.Context) error {
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Please ensure the date is between 1/1/2000 and 12/30/2095")
 
-		return cli.NewExitError("", 1)
+		return cli.Exit("", 1)
 	}
 
 	printGregorian(globalWriter, d.Gregorian())

--- a/cmd/nepcal/main.go
+++ b/cmd/nepcal/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-const version = "v1.1.0"
+const version = "v1.3.0"
 
 // Cheap testing.
 var globalWriter io.Writer = os.Stdout

--- a/cmd/nepcal/main.go
+++ b/cmd/nepcal/main.go
@@ -40,6 +40,7 @@ func bootstrapCli() *cli.App {
 		Usage:           "Calendar and conversion utilities for Nepali dates",
 		HideVersion:     true,
 		HideHelpCommand: true,
+		Action:          nc.showCalendar,
 		Authors: []*cli.Author{
 			{
 				Name:  "Srishan Bhattarai",

--- a/cmd/nepcal/main.go
+++ b/cmd/nepcal/main.go
@@ -38,8 +38,8 @@ func bootstrapCli() *cli.App {
 		Name:            "nepcal",
 		Version:         version,
 		Usage:           "Calendar and conversion utilities for Nepali dates",
-		HideVersion:     true,
-		HideHelpCommand: true,
+		HideVersion:     false,
+		HideHelpCommand: false,
 		Action:          nc.showCalendar,
 		Authors: []*cli.Author{
 			{

--- a/cmd/nepcal/main.go
+++ b/cmd/nepcal/main.go
@@ -41,6 +41,10 @@ func bootstrapCli() *cli.App {
 		HideVersion:     false,
 		HideHelpCommand: false,
 		Action:          nc.showCalendar,
+		CommandNotFound: func(c *cli.Context, command string) {
+			fmt.Printf("No matching sub command: %s\n\n", command)
+			cli.ShowAppHelpAndExit(c, 1)
+		},
 		Authors: []*cli.Author{
 			{
 				Name:  "Srishan Bhattarai",

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/fatih/color v1.9.0
 	github.com/stretchr/testify v1.7.0
-	github.com/urfave/cli/v2 v2.2.0
+	github.com/urfave/cli/v2 v2.3.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -19,13 +19,13 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/urfave/cli/v2 v2.2.0 h1:JTTnM6wKzdA0Jqodd966MVj4vWbbquZykeX1sKbe2C4=
-github.com/urfave/cli/v2 v2.2.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
+github.com/urfave/cli/v2 v2.3.0 h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=
+github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
This is slightly opinionated but just like `cal`, `nepcal` should also return the calendar view as it is the primary functionality. Other commands can be found with `nepcal help`.

```
$ nepcal
    मंसिर १, २०७८
 Su Mo Tu We Th Fr Sa
          १  २  ३  ४
 ५  ६  ७  ८  ९  १० ११
 १२ १३ १४ १५ १६ १७ १८
 १९ २० २१ २२ २३ २४ २५
 २६ २७ २८ २९
```

Other changes include:

- Upgrade `urfave/cli` to `v2.3.0`
- Remove usage of deprecated method `cli.NewExitError` in favor of `cli.Exit`
- Revive help and version
- Readme updates
- Add an error message if a sub-command is not found

Increased the version to `1.3.0` hoping that this gets merged and is considered as a minor release. 😉 