### PR TITLE
Disallow normalization and improve robustness against invalid input

### DIFF
--- a/cmd/nepcal/cli.go
+++ b/cmd/nepcal/cli.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -52,7 +53,7 @@ func (nepcalCli) convADToBS(c *cli.Context) error {
 	ad := gregorian(yy, mm, dd)
 	bs, err := nepcal.FromGregorian(ad)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "Please supply a date after 04/14/1943.")
+		fmt.Fprintln(os.Stderr, "Please ensure the date is between 04-13-1918 and 04-12-2044 A.D.")
 
 		return cli.Exit("", 1)
 	}
@@ -74,7 +75,11 @@ func (nepcalCli) convBSToAD(c *cli.Context) error {
 
 	d, err := nepcal.Date(yy, nepcal.Month(mm), dd)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "Please ensure the date is between 1/1/2000 and 12/30/2095")
+		if errors.Is(err, nepcal.ErrOutOfBounds) {
+			fmt.Fprintln(os.Stderr, "Please ensure the date is between 01-01-1975 and 12-30-2100 B.S.")
+		} else {
+			fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
+		}
 
 		return cli.Exit("", 1)
 	}

--- a/cmd/nepcal/main_test.go
+++ b/cmd/nepcal/main_test.go
@@ -73,11 +73,11 @@ func TestParseRawDate(t *testing.T) {
 		{"underflow month", "00-21-1994", -1, -1, -1, false},
 		{"underflow year", "14-21-199", -1, -1, -1, false},
 		{"overflow year", "14-21-19900", -1, -1, -1, false},
-		{"inconversibe month", "aa-21-1994", -1, -1, -1, false},
-		{"inconversibe day", "08-aa-1994", -1, -1, -1, false},
-		{"inconversibe year", "08-21-xyz", -1, -1, -1, false},
+		{"inconversible month", "aa-21-1994", -1, -1, -1, false},
+		{"inconversible day", "08-aa-1994", -1, -1, -1, false},
+		{"inconversible year", "08-21-xyz", -1, -1, -1, false},
 		{"underflow number of elements", "08-21", -1, -1, -1, false},
-		{"overflwo number of elements", "08-21-1994-01", -1, -1, -1, false},
+		{"overflow number of elements", "08-21-1994-01", -1, -1, -1, false},
 	}
 
 	for _, test := range tests {

--- a/nepcal/util.go
+++ b/nepcal/util.go
@@ -1,27 +1,37 @@
 package nepcal
 
 import (
-	"fmt"
 	"time"
 )
 
-// IsInRangeGregorian checks if 't' is after 04/14/1943.
+// IsInRangeGregorian checks if 't' is inside Nepcal's supported range of dates.
 func IsInRangeGregorian(t time.Time) bool {
 	adLBound := gregorian(adLBoundY, adLBoundM, adLBoundD)
+	adUBound := gregorian(adUBoundY, adUBoundM, adUBoundD)
 
-	return t.Equal(adLBound) || t.After(adLBound)
+	satisfiesLowerBound := t.Equal(adLBound) || t.After(adLBound)
+	satisfiesUpperBound := t.Equal(adUBound) || t.Before(adUBound)
+
+	return satisfiesLowerBound && satisfiesUpperBound
 }
 
 // IsInRangeBS checks if the provided date represents a B.S. that
 // we have data for and can be supported for conversions to/from A.D.
 func IsInRangeBS(year int, month Month, day int) bool {
+	if month < Baisakh || month > Chaitra {
+		return false
+	}
+
+	t := (raw{year, month, day}).String()
+
 	// Lower bound raw date.
 	bslow := raw{bsLBoundY, bsLBoundM, bsLBoundD}
+	bshigh := raw{bsUBoundY, bsUBoundM, bsUBoundD}
 
-	// Input raw date.
-	inraw := raw{year, month, day}
+	satisfiesLowerBound := t >= bslow.String()
+	satisfiesUpperBound := t <= bshigh.String()
 
-	return after(inraw, bslow)
+	return satisfiesLowerBound && satisfiesUpperBound
 }
 
 // IsInRangeYear return true if the provided bsYear is within the supported
@@ -47,14 +57,4 @@ func numDaysInYear(year int) int {
 	}
 
 	return sum
-}
-
-// Check if 't' is after 'u'.
-func after(t raw, u raw) bool {
-	// Comparing their string representations is an easy way to do this
-	// as we do not deal with sub-day precisions.
-	tstr := fmt.Sprintf("%d-%02d-%02d", t.year, t.month, t.day)
-	ustr := fmt.Sprintf("%d-%02d-%02d", u.year, u.month, u.day)
-
-	return tstr > ustr
 }


### PR DESCRIPTION
## Changes
- Reject B.S. dates (via the Date() function) that would have normalized. (fixes #79)
- Add upper bound checks for date limits, don't know why this wasn't
  there already
- Go' iota based enums are very loosely typed so a nepcal.Month value of
  64 was possible since they are just ints. Added a check for this.

## Notes
There is more to #79 than may initially seem. (todo)